### PR TITLE
Use Template Haskell based logging functions. ...

### DIFF
--- a/canteven-http.cabal
+++ b/canteven-http.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                canteven-http
-version:             0.1.1.0
+version:             0.1.1.1
 synopsis:            Utilities for HTTP programming.
 -- description:         
 homepage:            https://github.com/SumAll/canteven-http

--- a/src/Canteven/HTTP.hs
+++ b/src/Canteven/HTTP.hs
@@ -20,7 +20,7 @@ import Control.Concurrent (threadDelay)
 import Control.Exception (SomeException)
 import Control.Monad (void)
 import Control.Monad.Catch (try, throwM)
-import Control.Monad.Logger (runLoggingT, LoggingT, logInfo)
+import Control.Monad.Logger (runLoggingT, LoggingT, logInfo, logError)
 import Control.Monad.Trans.Class (lift)
 import Data.ByteString.Lazy (ByteString, fromStrict)
 import Data.Monoid ((<>))
@@ -126,7 +126,7 @@ logExceptionsAndContinue logging app req respond = (`runLoggingT` logging) $
     logProblem :: SomeException -> LoggingT IO UUID
     logProblem err = do
       uuid <- getUUID
-      $(logInfo) . pack
+      $(logError) . pack
         $ "Internal Server Error [" ++ show uuid ++ "]: "
         ++ show (err :: SomeException)
       return uuid

--- a/src/Canteven/HTTP.hs
+++ b/src/Canteven/HTTP.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
 {- |
   This module provides some utilities that make for better HTTP-based
   programs.
@@ -19,7 +20,7 @@ import Control.Concurrent (threadDelay)
 import Control.Exception (SomeException)
 import Control.Monad (void)
 import Control.Monad.Catch (try, throwM)
-import Control.Monad.Logger (runLoggingT, LoggingT, logInfoN)
+import Control.Monad.Logger (runLoggingT, LoggingT, logInfo)
 import Control.Monad.Trans.Class (lift)
 import Data.ByteString.Lazy (ByteString, fromStrict)
 import Data.Monoid ((<>))
@@ -125,7 +126,7 @@ logExceptionsAndContinue logging app req respond = (`runLoggingT` logging) $
     logProblem :: SomeException -> LoggingT IO UUID
     logProblem err = do
       uuid <- getUUID
-      logInfoN . pack
+      $(logInfo) . pack
         $ "Internal Server Error [" ++ show uuid ++ "]: "
         ++ show (err :: SomeException)
       return uuid
@@ -141,7 +142,7 @@ logExceptionsAndContinue logging app req respond = (`runLoggingT` logging) $
 -}
 requestLogging :: LoggerTImpl -> Middleware
 requestLogging logging app req respond = (`runLoggingT` logging) $ do
-    logInfoN . pack
+    $(logInfo) . pack
       $ "Starting request: " ++ reqStr
     lift . app req . loggingRespond =<< lift getCurrentTime
   where
@@ -154,7 +155,7 @@ requestLogging logging app req respond = (`runLoggingT` logging) $ do
       -}
       ack <- lift $ respond response
       now <- lift getCurrentTime
-      logInfoN . pack
+      $(logInfo) . pack
         $ reqStr ++ " --> " ++ showStatus (responseStatus response)
         ++ " (" ++ show (diffUTCTime now start) ++ ")"
       return ack


### PR DESCRIPTION
I had been trying to avoid introducing template haskell into this
library, however there are a couple of really good reasons why we
should use the template haskell functions.

The first is that without template haskell, the module and file location
show up as `<unknown>` in the log files. While this information may
not turn out to be super useful to programmer trying to debug a
program, it is extremely frustrating to see `<unknown>` and not know
whether the location information would have been helpful or not.
Providing the location lessens the user's uncertainty about what they
are looking at.

Secondly, without the module information, it is impossible to
configure a logging system to take special action for log messages
originating from that module, e.g. like using a higher or lower
logging level than the rest of the system.