### PR TITLE
Add static files as build dependencies. ...

### DIFF
--- a/.src/Canteven/Internal.hs
+++ b/.src/Canteven/Internal.hs
@@ -9,6 +9,7 @@ import Control.Monad (join)
 import Data.List ((\\))
 import Data.Maybe (catMaybes)
 import Language.Haskell.TH (TExp, Q, runIO)
+import Language.Haskell.TH.Syntax (addDependentFile)
 import Network.HTTP.Types (ok200)
 import Network.Mime (defaultMimeLookup)
 import Network.Wai (Middleware, responseLBS, pathInfo)
@@ -36,7 +37,7 @@ staticSite :: FilePath -> Q (TExp Middleware)
 staticSite baseDir = join . runIO $ do
     files <- readStaticFiles
     mapM_ (printResource . fst) files
-    return $ [||
+    return $ mapM_ (addDependentFile . ((baseDir ++ "/") ++) . fst) files >> [||
         let
           {- |
             Build a middleware that serves a single static file path, or

--- a/canteven-http.cabal
+++ b/canteven-http.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                canteven-http
-version:             0.1.5.0
+version:             0.1.5.1
 synopsis:            Utilities for HTTP programming.
 -- description:         
 homepage:            https://github.com/SumAll/canteven-http


### PR DESCRIPTION
This does not catch the case where new files are added to the static
directory, but at least if any of the existing static files are updated
this will cause a re-build of the module that loads them.